### PR TITLE
feat: support global config via module options in nuxt config

### DIFF
--- a/docs/content/3.guide/1.nuxt-packages/2.naive-ui.md
+++ b/docs/content/3.guide/1.nuxt-packages/2.naive-ui.md
@@ -32,7 +32,18 @@ npm add @huntersofbook/naive-ui-nuxt
 export default defineNuxtConfig({
   modules: [
     '@huntersofbook/naive-ui-nuxt'
-  ]
+  ],
+  // Optionally, specify global naive-ui config
+  // Supports options that are normally set via 'n-config-provider'
+  // https://www.naiveui.com/en-US/os-theme/docs/customize-theme
+  naiveUI: {
+    themeOverrides: {
+      common: {
+        primaryColor: '#ff0000',
+        primaryColorHover: '#8b0000'
+      }
+    }
+  }
 })
 ```
 

--- a/packages/naive-ui-nuxt/README.md
+++ b/packages/naive-ui-nuxt/README.md
@@ -27,7 +27,19 @@ npm add @huntersofbook/naive-ui-nuxt
 export default defineNuxtConfig({
   modules: [
     '@huntersofbook/naive-ui-nuxt'
-  ]
+  ],
+
+  // Optionally, specify global naive-ui config
+  // Supports options that are normally set via 'n-config-provider'
+  // https://www.naiveui.com/en-US/os-theme/docs/customize-theme
+  naiveUI: {
+    themeOverrides: {
+      common: {
+        primaryColor: '#ff0000',
+        primaryColorHover: '#8b0000'
+      }
+    }
+  }
 })
 ```
 

--- a/packages/naive-ui-nuxt/playground/nuxt.config.ts
+++ b/packages/naive-ui-nuxt/playground/nuxt.config.ts
@@ -3,5 +3,14 @@ import { defineNuxtConfig } from 'nuxt/config'
 import naiveUI from '..'
 
 export default defineNuxtConfig({
-  modules: [naiveUI]
+  modules: [naiveUI],
+
+  naiveUI: {
+    themeOverrides: {
+      common: {
+        primaryColor: '#ff0000',
+        primaryColorHover: '#8b0000'
+      }
+    }
+  }
 })

--- a/packages/naive-ui-nuxt/playground/pages/globalConfig.vue
+++ b/packages/naive-ui-nuxt/playground/pages/globalConfig.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Displays controls in the style determined by the config in
+    <code>nuxt.config.ts</code>.
+    <div class="mx-auto mt-4 max-w-sm">
+      <NButton>Default</NButton>
+      <NButton>Default</NButton>
+      <NInput>Default</NInput>
+    </div>
+  </div>
+</template>

--- a/packages/naive-ui-nuxt/playground/pages/index.vue
+++ b/packages/naive-ui-nuxt/playground/pages/index.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div>
-    <NConfigProvider :theme="darkTheme">
+    <NConfigProvider>
       <NGlobalStyle />
       <div class="mx-auto mt-4 max-w-sm">
         <NButton>Default</NButton>

--- a/packages/naive-ui-nuxt/playground/pages/naive.vue
+++ b/packages/naive-ui-nuxt/playground/pages/naive.vue
@@ -1,4 +1,6 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { darkTheme } from 'naive-ui'
+</script>
 
 <template>
   <NConfigProvider :theme="darkTheme">

--- a/packages/naive-ui-nuxt/src/runtime/config.ts
+++ b/packages/naive-ui-nuxt/src/runtime/config.ts
@@ -1,0 +1,34 @@
+import { Plugin as VuePlugin, computed } from 'vue'
+
+import { ModuleOptions } from '../module'
+
+import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+
+const plugin: VuePlugin = {
+  install: (app, options: ModuleOptions) => {
+    app.provide('n-config-provider', {
+      mergedThemeHashRef: computed(() => ''),
+      mergedBreakpointsRef: computed(() => undefined),
+      mergedRtlRef: computed(() => undefined),
+      mergedIconsRef: computed(() => undefined),
+      mergedComponentPropsRef: computed(() => undefined),
+      mergedBorderedRef: computed(() => undefined),
+      mergedNamespaceRef: computed(() => undefined),
+      mergedClsPrefixRef: computed(() => undefined),
+      mergedLocaleRef: computed(() => undefined),
+      mergedDateLocaleRef: computed(() => undefined),
+      mergedHljsRef: computed(() => undefined),
+      mergedThemeRef: computed(() => undefined),
+      mergedThemeOverridesRef: computed(() => options.themeOverrides),
+      inlineThemeDisabled: false,
+      preflightStyleDisabled: false
+    })
+  }
+}
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const config = useRuntimeConfig()?.public?.naiveUI
+  if (config) {
+    nuxtApp.vueApp.use(plugin, config)
+  }
+})


### PR DESCRIPTION
Allow to specify options to naive-ui via global module options, e.g. in `nuxt.config.ts`:
```ts
naiveUI: {
    themeOverrides: {
      common: {
        primaryColor: '#ff0000',
        primaryColorHover: '#8b0000'
      }
    }
  }
```
Currently, only `themeOverrides` is supported with other config options coming in a follow-up PR.